### PR TITLE
Various small improvements

### DIFF
--- a/Cacom/src/ast.rs
+++ b/Cacom/src/ast.rs
@@ -27,7 +27,7 @@ pub enum AST {
     },
     List {
         size: Box<AST>,
-        values: Vec<Box<AST>>,
+        values: Vec<AST>,
     },
 
     AccessVariable {
@@ -56,11 +56,11 @@ pub enum AST {
 
     CallFunction {
         name: String,
-        arguments: Vec<Box<AST>>,
+        arguments: Vec<AST>,
     },
 
-    Top(Vec<Box<AST>>),
-    Block(Vec<Box<AST>>),
+    Top(Vec<AST>),
+    Block(Vec<AST>),
     While {
         guard: Box<AST>,
         body: Box<AST>,
@@ -74,7 +74,7 @@ pub enum AST {
 
     Operator {
         op: Opcode,
-        arguments: Vec<Box<AST>>,
+        arguments: Vec<AST>,
     },
 
     Return(Box<AST>),
@@ -183,31 +183,5 @@ impl AST {
             }
         }
         _dump(self, String::from(""));
-    }
-}
-
-pub trait IntoBoxed {
-    type Into;
-    fn into_boxed(self) -> Self::Into;
-}
-
-impl IntoBoxed for AST {
-    type Into = Box<Self>;
-    fn into_boxed(self) -> Self::Into {
-        Box::new(self)
-    }
-}
-
-impl IntoBoxed for Vec<AST> {
-    type Into = Vec<Box<AST>>;
-    fn into_boxed(self) -> Self::Into {
-        self.into_iter().map(|ast| ast.into_boxed()).collect()
-    }
-}
-
-impl IntoBoxed for Option<AST> {
-    type Into = Option<Box<AST>>;
-    fn into_boxed(self) -> Self::Into {
-        self.map(|ast| ast.into_boxed())
     }
 }

--- a/Cacom/src/compiler.rs
+++ b/Cacom/src/compiler.rs
@@ -274,7 +274,9 @@ fn _compile(
             _compile(&then_branch, code,context, constant_pool, globals, drop)?;
             code.add(Bytecode::Label(String::from("if_false")));
             if let Some(else_body) = else_branch {
-                _compile(&else_body, code,context, constant_pool, globals, false)?;
+                _compile(&else_body, code, context, constant_pool, globals, drop)?;
+            } else if !drop {
+                code.add(Bytecode::PushUnit);
             }
         },
         AST::Operator { op, arguments } => {

--- a/Cacom/src/grammar.lalrpop
+++ b/Cacom/src/grammar.lalrpop
@@ -111,6 +111,8 @@ Term: AST = {
 }
 
 LowPrio: AST = {
+    TRUE => AST::Bool(true),
+    FALSE => AST::Bool(false),
     Number => <>,
     String => AST::String(<>),
     Call => <>,

--- a/Cacom/src/grammar.lalrpop
+++ b/Cacom/src/grammar.lalrpop
@@ -60,10 +60,9 @@ pub TopLevel: AST = {
 }
 
 TopLevelExpressions: Vec<AST> = {
-    <first: TopLevelExpression> <others: (SEMICOLON <TopLevelExpression>)*> SEMICOLON? => {
-        let mut all = VecDeque::from(others);
-        all.push_front(first);
-        Vec::from(all)
+    <mut elements: (<TopLevelExpression> SEMICOLON)*> <element: TopLevelExpression> SEMICOLON? => {
+        elements.push(element);
+        elements
     }
 }
 
@@ -74,10 +73,9 @@ TopLevelExpression: AST = {
 }
 
 Statements: Vec<AST> = {
-    <first: Statement> <others: (SEMICOLON <Statement>)*> SEMICOLON? => {
-        let mut all = VecDeque::from(others);
-        all.push_front(first);
-        Vec::from(all)
+    <mut elements: (<Statement> SEMICOLON)*> <element: Statement> SEMICOLON? => {
+        elements.push(element);
+        elements
     }
 }
 
@@ -177,24 +175,19 @@ Parameters: Vec<String> = {
 }
 
 Arguments: Vec<AST> = {
-    <elements: (<Expr> COMMA)*> <element: Expr?> => {
+    <mut elements: (<Expr> COMMA)*> <element: Expr?> => {
         match element {
             None => elements,
-            Some(e) => { let mut elements = elements; elements.push(e); elements }
+            Some(e) => { elements.push(e); elements }
         }
     }
 }
 
 Conditional: AST = {
-    IF <guard: Expr> <then: Block> ELSE <els: Block> =>
+    IF <guard: Expr> <then: Block> <els: (ELSE <Block>)?> =>
                     AST::Conditional{guard: Box::new(guard),
                             then_branch: Box::new(then),
-                            else_branch: Some(Box::new(els))},
-
-    IF <guard: Expr> <then: Block> =>
-                    AST::Conditional{guard: Box::new(guard),
-                            then_branch: Box::new(then),
-                            else_branch: None}
+                            else_branch: els.map(Box::new)},
 }
 
 Return: AST = {

--- a/Cacom/src/grammar.lalrpop
+++ b/Cacom/src/grammar.lalrpop
@@ -4,8 +4,7 @@
 // https://github.com/kondziu
 //
 
-use crate::ast::{AST, Opcode, IntoBoxed};
-use crate::grammar::AST::NoneVal;
+use crate::ast::{AST, Opcode};
 use std::collections::VecDeque;
 use std::str::FromStr;
 
@@ -56,8 +55,8 @@ match {
 }
 
 pub TopLevel: AST = {
-    <toplevel: TopLevelExpressions> => AST::Top(toplevel.into_boxed()),
-                                    => AST::Top(vec![NoneVal.into_boxed()]),
+    <toplevel: TopLevelExpressions> => AST::Top(toplevel),
+                                    => AST::Top(vec![AST::NoneVal]),
 }
 
 TopLevelExpressions: Vec<AST> = {
@@ -92,17 +91,17 @@ Statement: AST = {
 }
 
 Expr: AST = {
-    <left:Expr> <op:LogicalOp> <right: AExpr> => AST::Operator{op: op, arguments: vec![Box::new(left), Box::new(right)]},
+    <left:Expr> <op:LogicalOp> <right: AExpr> => AST::Operator{op: op, arguments: vec![left, right]},
     AExpr,
 }
 
 AExpr: AST = {
-    <left:AExpr> <op:ExprOp> <right:Factor> => AST::Operator{op: op, arguments: vec![Box::new(left), Box::new(right)]},
+    <left:AExpr> <op:ExprOp> <right:Factor> => AST::Operator{op: op, arguments: vec![left, right]},
     Factor,
 }
 
 Factor: AST = {
-    <left:Factor> <op:TermOp> <right:Term> => AST::Operator{op: op, arguments: vec![Box::new(left), Box::new(right)]},
+    <left:Factor> <op:TermOp> <right:Term> => AST::Operator{op: op, arguments: vec![left, right]},
     Term,
 }
 
@@ -155,13 +154,13 @@ String: String = {
 }
 
 Block: AST = {
-    CURLYBOPEN <expressions: Statements> CURLYBCLOSE => AST::Block(expressions.into_boxed()),
+    CURLYBOPEN <expressions: Statements> CURLYBCLOSE => AST::Block(expressions),
     CURLYBOPEN CURLYBCLOSE => AST::NoneVal,
 }
 
 FunDecl: AST = {
     DEF <name: Identifier> <parameters: Parameters> ASSIGN <body: Statement> => {
-        AST::Function{name, parameters, body: body.into_boxed()}
+        AST::Function{name, parameters, body: Box::new(body)}
     }
 }
 
@@ -175,27 +174,27 @@ Parameters: Vec<String> = {
         }
 }
 
-Arguments: Vec<Box<AST>> = {
+Arguments: Vec<AST> = {
     <elements: (<Expr> COMMA)*> <element: Expr?> => {
         match element {
-            None => elements.into_iter().map(|x| x.into_boxed()).collect(),
-            Some(e) => { let mut elements = elements; elements.push(e); elements.into_iter().map(|x| x.into_boxed()).collect() }
+            None => elements,
+            Some(e) => { let mut elements = elements; elements.push(e); elements }
         }
     }
 }
 
 Conditional: AST = {
     IF <guard: Expr> <then: Block> ELSE <els: Block> =>
-                    AST::Conditional{guard: guard.into_boxed(),
-                            then_branch: then.into_boxed(),
-                            else_branch: Some(els.into_boxed())},
+                    AST::Conditional{guard: Box::new(guard),
+                            then_branch: Box::new(then),
+                            else_branch: Some(Box::new(els))},
 
     IF <guard: Expr> <then: Block> =>
-                    AST::Conditional{guard: guard.into_boxed(),
-                            then_branch: then.into_boxed(),
+                    AST::Conditional{guard: Box::new(guard),
+                            then_branch: Box::new(then),
                             else_branch: None}
 }
 
 Return: AST = {
-    RETURN <expr: Expr> => AST::Return(expr.into_boxed())
+    RETURN <expr: Expr> => AST::Return(Box::new(expr))
 }


### PR DESCRIPTION
Mostly to parser, but also in optional `else` codegen. As far as I can tell there is no jump over the `else` if the condition is true. I didn't mess with that.

LALRPOP grammer could maybe be simplified further with [macros](https://lalrpop.github.io/lalrpop/tutorial/006_macros.html), like the showcased `Comma` one. 