### PR TITLE
Values as hash table keys and other improvements

### DIFF
--- a/Caby/src/hashtable.c
+++ b/Caby/src/hashtable.c
@@ -16,7 +16,8 @@ void free_table(struct table* t) {
 /// otherwise returns entry saved under the key.
 static struct entry* find_entry(struct entry* entries, size_t capacity,
                                 struct object_string* key) {
-    u32 idx = key->hash % capacity;
+    // Assume the capacity is a power of two and do fast modulo using mask.
+    u32 idx = key->hash & (capacity - 1);
     struct entry* tombstone = NULL;
 
     for (;;) {
@@ -36,7 +37,7 @@ static struct entry* find_entry(struct entry* entries, size_t capacity,
             return e;
         }
 
-        idx = (idx + 1) % capacity;
+        idx = (idx + 1) & (capacity - 1);
     }
     UNREACHABLE();
 }

--- a/Caby/src/hashtable.h
+++ b/Caby/src/hashtable.h
@@ -7,7 +7,7 @@
 #define TABLE_MAX_LOAD 0.75
 
 struct entry {
-    struct object_string* key;
+    struct value key;
     struct value val;
 };
 
@@ -23,8 +23,8 @@ void free_table(struct table* t);
 
 /// Inserts the value under key.
 /// Returns true if the key wasn't in the table, otherwise returns false.
-bool table_set(struct table* t, struct object_string* key, struct value val);
+bool table_set(struct table* t, struct value key, struct value val);
 
-bool table_get(struct table* t, struct object_string* key, struct value* val);
+bool table_get(struct table* t, struct value key, struct value* val);
 
-bool table_delete(struct table* t, struct object_string* key);
+bool table_delete(struct table* t, struct value key);

--- a/Caby/src/object.c
+++ b/Caby/src/object.c
@@ -78,6 +78,46 @@ struct object_function* as_function_s(struct object* object) {
     return NULL;
 }
 
+
+u32 value_hash(struct value v) {
+    u8* p;
+    size_t len;
+    switch (v.type) {
+        case VAL_INT:
+            p = (u8*)&v.integer;
+            len = sizeof(v.integer);
+            break;
+        case VAL_BOOL:
+            p = (u8*)&v.boolean;
+            len = sizeof(v.boolean);
+            break;
+        case VAL_DOUBLE:
+            p = (u8*)&v.double_num;
+            len = sizeof(v.double_num);
+            break;
+        case VAL_OBJECT:
+            switch(v.object->type) {
+                case OBJECT_STRING: {
+                    struct object_string* s = as_string(v.object);
+                    return s->hash;
+                }
+                default:
+                    p = (u8*)&v.object;
+                    len = sizeof(v.object);
+            }
+            break;
+        case VAL_NONE:
+            len = 0;
+            break;
+    }
+    uint32_t hash = 2166136261u;
+    for (size_t i = 0; i < len; i++) {
+      hash ^= p[i];
+      hash *= 16777619;
+    }
+    return hash;
+}
+
 bool value_eq(struct value v1, struct value v2) {
     if (v1.type != v2.type)
         return false;

--- a/Caby/src/object.c
+++ b/Caby/src/object.c
@@ -19,7 +19,7 @@ struct object* to_object_s(struct value val) {
 static uint32_t hashString(const char* key, int length) {
   uint32_t hash = 2166136261u;
   for (int i = 0; i < length; i++) {
-    hash ^= (uint8_t)key[i];
+    hash ^= (u8)key[i];
     hash *= 16777619;
   }
   return hash;
@@ -32,7 +32,8 @@ struct object_string* new_string(const char* str) {
     n->size = len;
     n->hash = hashString(str, n->size);
     n->data = vmalloc(len + 1);
-    strcpy(n->data, str);
+    memcpy(n->data, str, n->size);
+    n->data[n->size] = '\0';
     return n;
 }
 

--- a/Caby/src/object.c
+++ b/Caby/src/object.c
@@ -96,6 +96,7 @@ u32 value_hash(struct value v) {
             len = sizeof(v.double_num);
             break;
         case VAL_OBJECT:
+            // TODO: should be able to use the below pointer hash when strings are interned
             switch(v.object->type) {
                 case OBJECT_STRING: {
                     struct object_string* s = as_string(v.object);

--- a/Caby/src/object.c
+++ b/Caby/src/object.c
@@ -77,3 +77,36 @@ struct object_function* as_function_s(struct object* object) {
     }
     return NULL;
 }
+
+bool value_eq(struct value v1, struct value v2) {
+    if (v1.type != v2.type)
+        return false;
+    switch (v1.type) {
+        case VAL_INT:
+            return v1.integer == v2.integer;
+        case VAL_BOOL:
+            return v1.boolean == v2.boolean;
+        case VAL_DOUBLE:
+            return v1.double_num == v2.double_num;
+        case VAL_OBJECT:
+            switch(v1.object->type) {
+                case OBJECT_STRING: {
+                    // TODO: use the below pointer comparison when strings are interned
+                    struct object_string* s1 = as_string(v1.object);
+                    struct object_string* s2 = as_string(v2.object);
+                    if (s1->size != s2->size)
+                        return false;
+                    if (s1->hash != s2->hash)
+                        return false;
+                    return memcmp(s1->data, s2->data, s1->size) == 0;
+                }
+                default:
+                    // Equal means "the same object" in the shallow sense,
+                    // not structurally equal
+                    return v1.object == v2.object;
+            }
+        case VAL_NONE:
+            return true;
+    }
+    UNREACHABLE();
+}

--- a/Caby/src/object.h
+++ b/Caby/src/object.h
@@ -65,7 +65,7 @@ struct value {
 #define NEW_INT(val) (struct value){.type = VAL_INT, .integer = (val)}
 #define NEW_BOOL(val) (struct value){.type = VAL_BOOL, .boolean = (val)}
 #define NEW_DOUBLE(val) (struct value){.type = VAL_DOUBLE, .double_num = (val)}
-#define NEW_OBJECT(val) (struct value){.type = VAL_OBJECT, .object = val}
+#define NEW_OBJECT(val) (struct value){.type = VAL_OBJECT, .object = (struct object*)(val)}
 #define NEW_NONE() (struct value){.type = VAL_NONE}
 
 /*

--- a/Caby/src/object.h
+++ b/Caby/src/object.h
@@ -101,3 +101,6 @@ struct object_function* new_function(u8 arity, u16 locals, struct bc_chunk c, u3
 struct object_function* as_function(struct object* object);
 
 struct object_function* as_function_s(struct object* object);
+
+// Compares two values for equality
+bool value_eq(struct value v1, struct value v2);

--- a/Caby/src/object.h
+++ b/Caby/src/object.h
@@ -102,5 +102,10 @@ struct object_function* as_function(struct object* object);
 
 struct object_function* as_function_s(struct object* object);
 
+
+// Computes hash of a value.
+// (Hashing of strings is separate, this hashes the pointer to string.)
+u32 value_hash(struct value v);
+
 // Compares two values for equality
 bool value_eq(struct value v1, struct value v2);

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -93,7 +93,7 @@ struct value interpret_string_concat(struct object* o1, struct object* o2) {
     memcpy(new_char + str1->size, str2->data, str2->size);
     new_char[size] = '\0';
 
-    return NEW_OBJECT((struct object*)new_string_move(new_char, size));
+    return NEW_OBJECT(new_string_move(new_char, size));
 }
 
 void interpret_print(struct vm_state* vm) {

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -160,42 +160,6 @@ void interpret_print(struct vm_state* vm) {
     push(vm, NEW_NONE());
 }
 
-bool interpret_eq(struct vm_state* vm) {
-    struct value v1 = pop(vm);
-    struct value v2 = pop(vm);
-    bool eq = false;
-    if (v1.type == v2.type) {
-        switch (v1.type) {
-            case VAL_INT:
-                eq = v1.integer == v2.integer;
-                break;
-            case VAL_BOOL:
-                eq = v1.boolean == v2.boolean;
-                break;
-            case VAL_DOUBLE:
-                eq = v1.double_num == v2.double_num;
-                break;
-            case VAL_OBJECT:
-                switch(v1.object->type) {
-                    case OBJECT_STRING:
-                        // TODO: Maybe compare hashes?
-                        eq = strcmp(as_string(v1.object)->data,
-                                    as_string(v2.object)->data) == 0;
-                        break;
-                    case OBJECT_FUNCTION: {
-                        NOT_IMPLEMENTED();
-                        break;
-                    }
-                }
-                break;
-            case VAL_NONE:
-                eq = true;
-                break;
-        }
-    }
-    return eq;
-}
-
 static enum interpret_result interpret_ins(struct vm_state* vm, u8 ins) {
     switch (ins) {
         case OP_RETURN: {
@@ -300,7 +264,9 @@ static enum interpret_result interpret_ins(struct vm_state* vm, u8 ins) {
             break;
         }
         case OP_EQ: {
-            bool res = interpret_eq(vm);
+            struct value v1 = pop(vm);
+            struct value v2 = pop(vm);
+            bool res = value_eq(v1, v2);
             push(vm, NEW_BOOL(res));
             break;
         }

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -89,8 +89,9 @@ struct value interpret_string_concat(struct object* o1, struct object* o2) {
 
     u32 size = str1->size + str2->size;
     char* new_char = vmalloc(size + 1);
-    strncpy(new_char, str1->data, str1->size);
-    strcpy(new_char + str1->size, str2->data);
+    memcpy(new_char, str1->data, str1->size);
+    memcpy(new_char + str1->size, str2->data, str2->size);
+    new_char[size] = '\0';
 
     return NEW_OBJECT((struct object*)new_string_move(new_char, size));
 }

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -312,7 +312,8 @@ static enum interpret_result interpret_ins(struct vm_state* vm, u8 ins) {
             u32 name_idx = READ_4BYTES_BE(vm->ip);
             vm->ip += 4;
             struct object_string* name = read_string_cp(&vm->const_pool, name_idx);
-            bool new_v = table_set(&vm->globals, name, val);
+            struct value name_obj = NEW_OBJECT(name);
+            bool new_v = table_set(&vm->globals, name_obj, val);
             if (!new_v) {
                 fprintf(stderr, "Error: Variable '%s' is already defined.\n", name->data);
                 exit(6);
@@ -323,8 +324,9 @@ static enum interpret_result interpret_ins(struct vm_state* vm, u8 ins) {
             u32 name_idx = READ_4BYTES_BE(vm->ip);
             vm->ip += 4;
             struct object_string* name = read_string_cp(&vm->const_pool, name_idx);
+            struct value name_obj = NEW_OBJECT(name);
             struct value val;
-            if (!table_get(&vm->globals, name, &val)) {
+            if (!table_get(&vm->globals, name_obj, &val)) {
                 fprintf(stderr, "Error: Access to undefined variable '%s'.\n", name->data);
                 exit(6);
             }
@@ -335,8 +337,9 @@ static enum interpret_result interpret_ins(struct vm_state* vm, u8 ins) {
             u32 name_idx = READ_4BYTES_BE(vm->ip);
             vm->ip += 4;
             struct object_string* name = read_string_cp(&vm->const_pool, name_idx);
+            struct value name_obj = NEW_OBJECT(name);
             struct value v = pop(vm);
-            if (table_set(&vm->globals, name, v)) {
+            if (table_set(&vm->globals, name_obj, v)) {
                 fprintf(stderr, "Global variable '%s' is not defined!\n", name->data);
                 exit(1);
             }

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -326,7 +326,6 @@ static enum interpret_result interpret_ins(struct vm_state* vm, u8 ins) {
             vm->ip = &CURRENT_FUNCTION()->bc.data[READ_4BYTES_BE(vm->ip)];
             break;
         case OP_BRANCH_FALSE:
-            fallthrough;
         case OP_BRANCH: {
             struct value val = pop(vm);
             if (val.type != VAL_BOOL) {
@@ -342,7 +341,6 @@ static enum interpret_result interpret_ins(struct vm_state* vm, u8 ins) {
             break;
         }
         case OP_VAL_GLOBAL:
-        fallthrough;
         case OP_VAR_GLOBAL: {
             struct value val = pop(vm);
             u32 name_idx = READ_4BYTES_BE(vm->ip);

--- a/Caby/tests/hashmap_test.c
+++ b/Caby/tests/hashmap_test.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include "test.h"
 #include "../src/hashtable.h"
 
@@ -24,9 +26,14 @@ TEST(HashMapBasic) {
     struct value key2 = NEW_OBJECT(new_string("FOO"));
     struct value key3 = NEW_OBJECT(new_string("BAR"));
     struct value key4 = NEW_OBJECT(new_string("BAZ"));
+    struct value key5 = NEW_INT(1);
+    struct value key6 = NEW_INT(2);
+
     ASSERT_W(table_set(&t, key2, NEW_BOOL(true)));
     ASSERT_W(table_set(&t, key3, NEW_NONE()));
     ASSERT_W(table_set(&t, key4, NEW_DOUBLE(4.2)));
+    ASSERT_W(table_set(&t, key5, NEW_INT(42)));
+    ASSERT_W(table_set(&t, key6, key1));
 
     // Check that the keys exists
     ASSERT_W(table_get(&t, key1, &val_out));
@@ -37,8 +44,133 @@ TEST(HashMapBasic) {
     ASSERT_W(val_out.type == VAL_NONE);
     ASSERT_W(table_get(&t, key4, &val_out));
     ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
 
-    // Delete entries one by one
+    // Check reads/writes through equal bot not same "object" keys
+    struct value key7_1 = NEW_OBJECT(new_string("FOOBAR"));
+    struct value key7_2 = NEW_OBJECT(new_string("FOOBAR"));
+    ASSERT_W(table_set(&t, key7_1, NEW_INT(9)));
+    ASSERT_W(table_get(&t, key7_2, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 9);
+    ASSERT_W(table_get(&t, key7_1, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 9);
+    ASSERT_W(!table_set(&t, key7_2, NEW_DOUBLE(9.9)));
+    ASSERT_W(table_get(&t, key7_1, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 9.9);
+    ASSERT_W(table_get(&t, key7_2, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 9.9);
+
+    // Delete the above entry
+    ASSERT_W(table_delete(&t, key7_1));
+    ASSERT_W(!table_delete(&t, key7_1));
+    ASSERT_W(!table_delete(&t, key7_2));
+    ASSERT_W(table_get(&t, key1, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 5);
+    ASSERT_W(table_get(&t, key2, &val_out));
+    ASSERT_W(val_out.type == VAL_BOOL && val_out.boolean == true);
+    ASSERT_W(table_get(&t, key3, &val_out));
+    ASSERT_W(val_out.type == VAL_NONE);
+    ASSERT_W(table_get(&t, key4, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+
+
+    // Add a couple more entries to stress reallocation
+    struct value key7 = NEW_DOUBLE(1.111);
+    struct value key8 = NEW_OBJECT(new_string("key8"));
+    struct value key9 = NEW_BOOL(true);
+    struct value key10 = NEW_BOOL(false);
+
+    ASSERT_W(table_set(&t, key7, NEW_INT(70)));
+    ASSERT_W(table_get(&t, key1, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 5);
+    ASSERT_W(table_get(&t, key2, &val_out));
+    ASSERT_W(val_out.type == VAL_BOOL && val_out.boolean == true);
+    ASSERT_W(table_get(&t, key3, &val_out));
+    ASSERT_W(val_out.type == VAL_NONE);
+    ASSERT_W(table_get(&t, key4, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(!table_get(&t, key8, &val_out));
+    ASSERT_W(!table_get(&t, key9, &val_out));
+    ASSERT_W(!table_get(&t, key10, &val_out));
+
+
+    ASSERT_W(table_set(&t, key8, NEW_INT(80)));
+    ASSERT_W(table_get(&t, key1, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 5);
+    ASSERT_W(table_get(&t, key2, &val_out));
+    ASSERT_W(val_out.type == VAL_BOOL && val_out.boolean == true);
+    ASSERT_W(table_get(&t, key3, &val_out));
+    ASSERT_W(val_out.type == VAL_NONE);
+    ASSERT_W(table_get(&t, key4, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(!table_get(&t, key9, &val_out));
+    ASSERT_W(!table_get(&t, key10, &val_out));
+
+    ASSERT_W(table_set(&t, key9, NEW_INT(90)));
+    ASSERT_W(table_get(&t, key1, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 5);
+    ASSERT_W(table_get(&t, key2, &val_out));
+    ASSERT_W(val_out.type == VAL_BOOL && val_out.boolean == true);
+    ASSERT_W(table_get(&t, key3, &val_out));
+    ASSERT_W(val_out.type == VAL_NONE);
+    ASSERT_W(table_get(&t, key4, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(!table_get(&t, key10, &val_out));
+
+    ASSERT_W(table_set(&t, key10, NEW_INT(100)));
+    ASSERT_W(table_get(&t, key1, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 5);
+    ASSERT_W(table_get(&t, key2, &val_out));
+    ASSERT_W(val_out.type == VAL_BOOL && val_out.boolean == true);
+    ASSERT_W(table_get(&t, key3, &val_out));
+    ASSERT_W(val_out.type == VAL_NONE);
+    ASSERT_W(table_get(&t, key4, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
+
+    // Delete all entries one by one
     ASSERT_W(table_delete(&t, key2));
     ASSERT_W(!table_delete(&t, key2));
     ASSERT_W(table_get(&t, key1, &val_out));
@@ -48,6 +180,18 @@ TEST(HashMapBasic) {
     ASSERT_W(val_out.type == VAL_NONE);
     ASSERT_W(table_get(&t, key4, &val_out));
     ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
 
     ASSERT_W(table_delete(&t, key3));
     ASSERT_W(!table_delete(&t, key3));
@@ -58,6 +202,18 @@ TEST(HashMapBasic) {
     ASSERT_W(!table_get(&t, key3, &val_out));
     ASSERT_W(table_get(&t, key4, &val_out));
     ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
 
     ASSERT_W(table_delete(&t, key1));
     ASSERT_W(!table_delete(&t, key1));
@@ -67,6 +223,19 @@ TEST(HashMapBasic) {
     ASSERT_W(!table_get(&t, key2, &val_out));
     ASSERT_W(!table_get(&t, key3, &val_out));
     ASSERT_W(table_get(&t, key4, &val_out));
+    ASSERT_W(val_out.type == VAL_DOUBLE && val_out.double_num == 4.2);
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
 
     ASSERT_W(table_delete(&t, key4));
     ASSERT_W(!table_delete(&t, key4));
@@ -77,6 +246,150 @@ TEST(HashMapBasic) {
     ASSERT_W(!table_get(&t, key2, &val_out));
     ASSERT_W(!table_get(&t, key3, &val_out));
     ASSERT_W(!table_get(&t, key4, &val_out));
+    ASSERT_W(table_get(&t, key5, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 42);
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
+
+    ASSERT_W(table_delete(&t, key5));
+    ASSERT_W(!table_delete(&t, key5));
+    ASSERT_W(!table_delete(&t, key4));
+    ASSERT_W(!table_delete(&t, key1));
+    ASSERT_W(!table_delete(&t, key3));
+    ASSERT_W(!table_delete(&t, key2));
+    ASSERT_W(!table_get(&t, key1, &val_out));
+    ASSERT_W(!table_get(&t, key2, &val_out));
+    ASSERT_W(!table_get(&t, key3, &val_out));
+    ASSERT_W(!table_get(&t, key4, &val_out));
+    ASSERT_W(!table_get(&t, key5, &val_out));
+    ASSERT_W(table_get(&t, key6, &val_out));
+    ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
+
+    ASSERT_W(table_delete(&t, key6));
+    ASSERT_W(!table_delete(&t, key6));
+    ASSERT_W(!table_delete(&t, key5));
+    ASSERT_W(!table_delete(&t, key4));
+    ASSERT_W(!table_delete(&t, key1));
+    ASSERT_W(!table_delete(&t, key3));
+    ASSERT_W(!table_delete(&t, key2));
+    ASSERT_W(!table_get(&t, key1, &val_out));
+    ASSERT_W(!table_get(&t, key2, &val_out));
+    ASSERT_W(!table_get(&t, key3, &val_out));
+    ASSERT_W(!table_get(&t, key4, &val_out));
+    ASSERT_W(!table_get(&t, key5, &val_out));
+    ASSERT_W(!table_get(&t, key6, &val_out));
+    ASSERT_W(table_get(&t, key7, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 70);
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
+
+    ASSERT_W(table_delete(&t, key7));
+    ASSERT_W(!table_delete(&t, key7));
+    ASSERT_W(!table_delete(&t, key6));
+    ASSERT_W(!table_delete(&t, key5));
+    ASSERT_W(!table_delete(&t, key4));
+    ASSERT_W(!table_delete(&t, key1));
+    ASSERT_W(!table_delete(&t, key3));
+    ASSERT_W(!table_delete(&t, key2));
+    ASSERT_W(!table_get(&t, key1, &val_out));
+    ASSERT_W(!table_get(&t, key2, &val_out));
+    ASSERT_W(!table_get(&t, key3, &val_out));
+    ASSERT_W(!table_get(&t, key4, &val_out));
+    ASSERT_W(!table_get(&t, key5, &val_out));
+    ASSERT_W(!table_get(&t, key6, &val_out));
+    ASSERT_W(!table_get(&t, key7, &val_out));
+    ASSERT_W(table_get(&t, key8, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 80);
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
+
+    ASSERT_W(table_delete(&t, key8));
+    ASSERT_W(!table_delete(&t, key8));
+    ASSERT_W(!table_delete(&t, key7));
+    ASSERT_W(!table_delete(&t, key6));
+    ASSERT_W(!table_delete(&t, key5));
+    ASSERT_W(!table_delete(&t, key4));
+    ASSERT_W(!table_delete(&t, key1));
+    ASSERT_W(!table_delete(&t, key3));
+    ASSERT_W(!table_delete(&t, key2));
+    ASSERT_W(!table_get(&t, key1, &val_out));
+    ASSERT_W(!table_get(&t, key2, &val_out));
+    ASSERT_W(!table_get(&t, key3, &val_out));
+    ASSERT_W(!table_get(&t, key4, &val_out));
+    ASSERT_W(!table_get(&t, key5, &val_out));
+    ASSERT_W(!table_get(&t, key6, &val_out));
+    ASSERT_W(!table_get(&t, key7, &val_out));
+    ASSERT_W(!table_get(&t, key8, &val_out));
+    ASSERT_W(table_get(&t, key9, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 90);
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
+
+    ASSERT_W(table_delete(&t, key9));
+    ASSERT_W(!table_delete(&t, key9));
+    ASSERT_W(!table_delete(&t, key8));
+    ASSERT_W(!table_delete(&t, key7));
+    ASSERT_W(!table_delete(&t, key6));
+    ASSERT_W(!table_delete(&t, key5));
+    ASSERT_W(!table_delete(&t, key4));
+    ASSERT_W(!table_delete(&t, key1));
+    ASSERT_W(!table_delete(&t, key3));
+    ASSERT_W(!table_delete(&t, key2));
+    ASSERT_W(!table_get(&t, key1, &val_out));
+    ASSERT_W(!table_get(&t, key2, &val_out));
+    ASSERT_W(!table_get(&t, key3, &val_out));
+    ASSERT_W(!table_get(&t, key4, &val_out));
+    ASSERT_W(!table_get(&t, key5, &val_out));
+    ASSERT_W(!table_get(&t, key6, &val_out));
+    ASSERT_W(!table_get(&t, key7, &val_out));
+    ASSERT_W(!table_get(&t, key8, &val_out));
+    ASSERT_W(!table_get(&t, key9, &val_out));
+    ASSERT_W(table_get(&t, key10, &val_out));
+    ASSERT_W(val_out.type == VAL_INT && val_out.integer == 100);
+
+
+    ASSERT_W(table_delete(&t, key10));
+    ASSERT_W(!table_delete(&t, key9));
+    ASSERT_W(!table_delete(&t, key8));
+    ASSERT_W(!table_delete(&t, key7));
+    ASSERT_W(!table_delete(&t, key6));
+    ASSERT_W(!table_delete(&t, key5));
+    ASSERT_W(!table_delete(&t, key4));
+    ASSERT_W(!table_delete(&t, key1));
+    ASSERT_W(!table_delete(&t, key3));
+    ASSERT_W(!table_delete(&t, key2));
+    ASSERT_W(!table_get(&t, key1, &val_out));
+    ASSERT_W(!table_get(&t, key2, &val_out));
+    ASSERT_W(!table_get(&t, key3, &val_out));
+    ASSERT_W(!table_get(&t, key4, &val_out));
+    ASSERT_W(!table_get(&t, key5, &val_out));
+    ASSERT_W(!table_get(&t, key6, &val_out));
+    ASSERT_W(!table_get(&t, key7, &val_out));
+    ASSERT_W(!table_get(&t, key8, &val_out));
+    ASSERT_W(!table_get(&t, key9, &val_out));
+    ASSERT_W(!table_get(&t, key10, &val_out));
 
     return 0;
 }

--- a/Caby/tests/hashmap_test.c
+++ b/Caby/tests/hashmap_test.c
@@ -9,7 +9,7 @@ TEST(HashMapBasic) {
 
     struct value val_out;
 
-    struct object_string* key1 = new_string("Hello, World!");
+    struct value key1 = NEW_OBJECT(new_string("Hello, World!"));
     table_set(&t, key1, NEW_INT(3));
     ASSERT_W(t.count == 1);
     ASSERT_W(table_get(&t, key1, &val_out));
@@ -21,9 +21,9 @@ TEST(HashMapBasic) {
     ASSERT_W(val_out.type == VAL_INT);
     ASSERT_W(val_out.integer == 5);
 
-    struct object_string* key2 = new_string("FOO");
-    struct object_string* key3 = new_string("BAR");
-    struct object_string* key4 = new_string("BAZ");
+    struct value key2 = NEW_OBJECT(new_string("FOO"));
+    struct value key3 = NEW_OBJECT(new_string("BAR"));
+    struct value key4 = NEW_OBJECT(new_string("BAZ"));
     ASSERT_W(table_set(&t, key2, NEW_BOOL(true)));
     ASSERT_W(table_set(&t, key3, NEW_NONE()));
     ASSERT_W(table_set(&t, key4, NEW_DOUBLE(4.2)));

--- a/Cacom/src/main.rs
+++ b/Cacom/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports, dead_code, unused_variables)]
 #[macro_use]
 extern crate lalrpop_util;
 extern crate clap;


### PR DESCRIPTION
This PR is more of a mix of unrelated concepts, the biggest is values as keys to hashes (formerly only strings were allowed). This is more me toying around with the code, so please don't feel pressured to even look at it or merge it.

Reviewing the commits one by one will be more comfortable, atleast I hope so.

The value hashing part is probably not ideal. The idea is (and the standard allows this) to view the values as `unsigned char` arrays and hash each char one by one. Though the code uses `uint_8`.

Also strings are currently not interned, so string pointers cannot be used for hash comparison (string equality doesn't mean string pointer equality) so this can be improved in the future if you plan on interning strings.