### PR TITLE
Add dockers

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "build" : {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vadimcn.vscode-lldb",
+                "llvm-vs-code-extensions.vscode-clangd",
+                "rust-lang.rust-analyzer"
+        ]
+        }
+    }
+}

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -11,7 +11,7 @@
 #include <assert.h>
 
 #ifdef __DEBUG__
-    #define DUMP_INS(ins) do {dissasemble_instruction(stderr, ins);runtime_error("\n");} while(false)
+    #define DUMP_INS(ins) do {dissasemble_instruction(stderr, ins);fprintf(stderr, "\n");} while(false)
 #else
     #define DUMP_INS(ins)
 #endif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:bullseye
+
+RUN apt-get update -y && \
+    apt-get install -y gcc \
+                       clang \
+                       cmake \
+                       python \
+                       valgrind \
+                       lldb \
+                       git \
+                       curl
+
+# rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+
+RUN echo 'source ${HOME}/.cargo/env' >> ${HOME}/.bashrc

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-
 # Quick and dirty build script, needs to be in project root folder
 
 cd Caby &&
-mkdir build;
+mkdir -p build;
 cd build;
-cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_BUILD_TYPE=${VM_TYPE:-Release}
 make
 cd ../..;
 cd Cacom;
-cargo build --release
+cargo build --${COMPILER_TYPE:-release}
 cd ..;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Quick and dirty build script, needs to be in project root folder
 
 cd Caby &&

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # A script for quick build and compile
 
 if [[ "$#" -ne 1 ]]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ./scripts/build.sh
 cd tests
 ./run_tests.sh ../Cacom/target/release/cacom ../Caby/build/caby


### PR DESCRIPTION
Added docker image for local development for VSCode. For now, the image server both for rust and C development.

Also, the scripts were made more modular, with env variables specifying which build type should be chosen.

There was also minor bugfix. When in debug mode, every instruction dump shouted that runtime error occured, even thought that wasn't true.

closes #26 