### PR TITLE
Add garbage collector

### DIFF
--- a/.github/workflows/build-action.yaml
+++ b/.github/workflows/build-action.yaml
@@ -25,7 +25,7 @@ jobs:
           cd ${{ github.workspace }}/Caby
           mkdir -p build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DCMAKE_BUILD_TYPE=GC_TEST
       - name: Build VM
         run: |
           cd ${{ github.workspace }}/Caby/build

--- a/Caby/CMakeLists.txt
+++ b/Caby/CMakeLists.txt
@@ -5,6 +5,7 @@ project(caby C)
 message("Build type: ${CMAKE_BUILD_TYPE}")
 
 set(CMAKE_C_FLAGS_SANITIZERS "-g -fsanitize=address -fsanitize=undefined -D__DEBUG__ -D__MEM_DEBUG__")
+set(CMAKE_C_FLAGS_GC "-g -fsanitize=address -fsanitize=undefined -D__DEBUG__ -D__MEM_DEBUG__ -D__GC_DEBUG__ -D__GC_STRESS__")
 set(CMAKE_C_FLAGS_DEBUG "-g -Wall -Wextra -pedantic -D__DEBUG__")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
 
@@ -17,9 +18,12 @@ target_link_libraries(caby m)
 
 enable_testing()
 
-add_executable(hashmap_test tests/hashmap_test.c src/hashtable.c src/object.c
-                            src/memory.c src/common.c src/bytecode.c
-                            src/memory/block_alloc.c src/gc.c)
+add_executable(hashmap_test src/main.c src/dissasembler.c src/bytecode.c
+                    src/common.c src/object.c src/memory.c src/vm.c
+                    src/serializer.c src/hashtable.c src/native.c
+                    src/memory/block_alloc.c src/gc.c)
+
+target_link_libraries(hashmap_test m)
 
 add_executable(blockalloc_test tests/blockalloc_test.c src/memory/block_alloc.c)
 

--- a/Caby/CMakeLists.txt
+++ b/Caby/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_C_FLAGS_RELEASE "-O2")
 add_executable(caby src/main.c src/dissasembler.c src/bytecode.c
                     src/common.c src/object.c src/memory.c src/vm.c
                     src/serializer.c src/hashtable.c src/native.c
-                    src/memory/block_alloc.c)
+                    src/memory/block_alloc.c src/gc.c)
 
 target_link_libraries(caby m)
 

--- a/Caby/CMakeLists.txt
+++ b/Caby/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(caby m)
 
 enable_testing()
 
-add_executable(hashmap_test src/main.c src/dissasembler.c src/bytecode.c
+add_executable(hashmap_test tests/hashmap_test.c src/dissasembler.c src/bytecode.c
                     src/common.c src/object.c src/memory.c src/vm.c
                     src/serializer.c src/hashtable.c src/native.c
                     src/memory/block_alloc.c src/gc.c)

--- a/Caby/CMakeLists.txt
+++ b/Caby/CMakeLists.txt
@@ -6,6 +6,7 @@ message("Build type: ${CMAKE_BUILD_TYPE}")
 
 set(CMAKE_C_FLAGS_SANITIZERS "-g -fsanitize=address -fsanitize=undefined -D__DEBUG__ -D__MEM_DEBUG__")
 set(CMAKE_C_FLAGS_GC "-g -fsanitize=address -fsanitize=undefined -D__DEBUG__ -D__MEM_DEBUG__ -D__GC_DEBUG__ -D__GC_STRESS__")
+set(CMAKE_C_FLAGS_GC_TEST "-g -fsanitize=address -fsanitize=undefined -D__GC_STRESS__")
 set(CMAKE_C_FLAGS_DEBUG "-g -Wall -Wextra -pedantic -D__DEBUG__")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
 

--- a/Caby/CMakeLists.txt
+++ b/Caby/CMakeLists.txt
@@ -19,7 +19,7 @@ enable_testing()
 
 add_executable(hashmap_test tests/hashmap_test.c src/hashtable.c src/object.c
                             src/memory.c src/common.c src/bytecode.c
-                            src/memory/block_alloc.c)
+                            src/memory/block_alloc.c src/gc.c)
 
 add_executable(blockalloc_test tests/blockalloc_test.c src/memory/block_alloc.c)
 

--- a/Caby/src/common.h
+++ b/Caby/src/common.h
@@ -34,7 +34,10 @@ size_t get_cap(size_t curr);
 /// Reallocates the array if the capacity is exceeded
 /// New array is returned if reallocation occured, else
 /// old one is returned. Capacity is updated accordingly.
-/// cnt - number of objects, len - size of one object
+/// Uses system realloc.
+///
+/// @param cnt - number of objects
+/// @param len - size of one object.
 void* handle_capacity(void* array, size_t cnt, size_t* cap, size_t len);
 
 #define NOT_IMPLEMENTED() do { fprintf(stderr,                     \

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -59,12 +59,18 @@ static void mark_table(struct gc_state* gc, struct table* table) {
 }
 
 static void mark_roots(vm_t* vm) {
+    // constant pool
+    for (size_t i = 0; i < vm->const_pool.len; ++i) {
+        mark_object(&vm->gc, vm->const_pool.data[i]);
+    }
+    
     // stack
     for (size_t i = 0; i < vm->stack_len; ++i) {
         mark_val(&vm->gc, &vm->op_stack[i]);
     }
     // globals
     mark_table(&vm->gc, &vm->globals);
+
     // locals in frames
     for (size_t i = 0; i < vm->frame_len; ++i) {
         for (size_t j = 0; j < vm->frames->function->locals; ++j) {

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -45,10 +45,10 @@ static void mark_table(struct gc_state* gc, struct table* table) {
     for (size_t i = 0; i < table->capacity; ++i) {
         struct entry* e = &table->entries[i];
         mark_val(gc, &e->key);
-        // TODO
-        // if (e->key.type != VAL_NONE) {
+        // TODO: Maybe not necessary
+        if (e->key.type != VAL_NONE) {
             mark_val(gc, &e->val);
-        // }
+        }
     }
 }
 

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -1,1 +1,58 @@
 #include "gc.h"
+#include "vm.h"
+#include "object.h"
+#include "hashtable.h"
+
+#define IS_MARKED(val) (val & 1)
+
+static void mark_object(struct object* obj) {
+    if (obj == NULL) {
+        return;
+    }
+    obj->gc_data = 1;
+#ifdef __GC_DEBUG__
+    GC_LOG("Marking object %p: ", obj);
+    dissasemble_object(obj);
+    GC_LOG("\n");
+#endif
+}
+
+static void mark_val(struct value* v) {
+    if (v->type == VAL_OBJECT) {
+        mark_object(v->object);
+    }
+}
+
+static void mark_table(struct table* table) {
+    for (size_t i = 0; i < table->capacity; ++i) {
+        struct entry* e = &table->entries[i];
+        mark_val(&e->key);
+        // TODO
+        // if (e->key.type != VAL_NONE) {
+            mark_val(&e->val);
+        // }
+    }
+}
+
+static void mark_roots(vm_t* vm) {
+    // stack
+    for (size_t i = 0; i < vm->stack_len; ++i) {
+        mark_val(&vm->op_stack[i]);
+    }
+    // globals
+    mark_table(&vm->globals);
+    // locals in frames
+    for (size_t i = 0; i < vm->frame_len; ++i) {
+        for (size_t j = 0; j < vm->frames->function->locals; ++j) {
+            mark_val(&vm->frames[i].slots[j]);
+        }
+    }
+}
+
+void gc_collect(vm_t* vm) {
+    GC_LOG("=== GC BEGIN ===\n");
+    
+    mark_roots(vm);
+
+    GC_LOG("=== GC END ===\n\n");
+}

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -1,4 +1,5 @@
 #include "gc.h"
+#include "bytecode.h"
 #include "common.h"
 #include "vm.h"
 #include "object.h"
@@ -6,11 +7,14 @@
 #include "memory.h"
 #include "dissasembler.h"
 
-#define IS_MARKED(val) ((val & 1) == 1)
+#define IS_MARKED(val) (((val) & 1) == 1)
 
 void init_gc(struct gc_state* gc) {
-    memset(gc, 0, sizeof(*gc));
+    gc->wl_capacity = 0;
+    gc->wl_count = 0;
+    gc->worklist = NULL;
     gc->next_gc = GC_THRESHOLD_START;
+    gc->gc_off = false;
 }
 
 void free_gc(struct gc_state* gc) {

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -4,11 +4,13 @@
 #include "object.h"
 #include "hashtable.h"
 #include "memory.h"
+#include "dissasembler.h"
 
 #define IS_MARKED(val) ((val & 1) == 1)
 
 void init_gc(struct gc_state* gc) {
     memset(gc, 0, sizeof(*gc));
+    gc->next_gc = GC_THRESHOLD_START;
 }
 
 void free_gc(struct gc_state* gc) {
@@ -30,7 +32,7 @@ static void mark_object(struct gc_state* gc, struct object* obj) {
     gc->worklist[gc->wl_count++] = obj;
 #ifdef __GC_DEBUG__
     GC_LOG("Marking object %p: ", obj);
-    dissasemble_object(obj);
+    dissasemble_object(stderr, obj);
     GC_LOG("\n");
 #endif
 }
@@ -126,6 +128,7 @@ void gc_collect(vm_t* vm) {
 
     mark_roots(vm);
     trace_references(&vm->gc);
+    GC_LOG("Sweeping...\n");
     sweep(vm);
 
     size_t after = mem_taken();

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -1,0 +1,1 @@
+#include "gc.h"

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -135,6 +135,10 @@ static void sweep(vm_t* vm) {
 }
 
 void gc_collect(vm_t* vm) {
+    if (vm->gc.gc_off) {
+        GC_LOG("Collection was called but GC is turned off\n");
+        return;
+    }
     GC_LOG("=== GC BEGIN ===\n");
     size_t before = mem_taken();
     GC_LOG("Taken memory: %lu/%luB\n", before, mem_total());

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -79,21 +79,20 @@ static void mark_roots(vm_t* vm) {
     }
 }
 
-static void close_obj(struct object* obj) {
+static void close_obj(vm_t* vm, struct object* obj) {
     switch (obj->type) {
+        case OBJECT_FUNCTION:
         case OBJECT_STRING:
         case OBJECT_NATIVE:
-        // We don't have to handle functions because they are not in the
-        // GC linked list of objects to be collected.
-        case OBJECT_FUNCTION:
-      break;
+            break;
     }
 }
 
-static void trace_references(struct gc_state* gc) {
+static void trace_references(vm_t* vm) {
+    struct gc_state* gc = &vm->gc;
     while (gc->wl_count > 0) {
-        struct object* obj = gc->worklist[--gc->wl_count];
-        close_obj(obj);
+        struct object* obj = vm->gc.worklist[--gc->wl_count];
+        close_obj(vm, obj);
     }
 }
 

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -105,14 +105,31 @@ static void sweep(vm_t* vm) {
             free_object(obj);
         }
     }
+
+    // struct object** obj = &vm->objects;
+    // while (*obj) {
+    //     if (IS_MARKED((*obj)->gc_data)) {
+    //         (*obj)->gc_data = 0;
+    //         obj = &(*obj)->next;
+    //     } else {
+    //         struct object* unreached = *obj;
+    //         *obj = (*obj)->next;
+    //         free_object(unreached);
+    //     }
+    // }
 }
 
 void gc_collect(vm_t* vm) {
     GC_LOG("=== GC BEGIN ===\n");
-    
+    size_t before = mem_taken();
+    GC_LOG("Taken memory: %lu/%luB\n", before, mem_total());
+
     mark_roots(vm);
     trace_references(&vm->gc);
     sweep(vm);
 
+    size_t after = mem_taken();
+    GC_LOG("Taken memory: %lu/%luB\n", after, mem_total());
+    GC_LOG("Difference: %luB\n", before - after);
     GC_LOG("=== GC END ===\n\n");
 }

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -112,8 +112,12 @@ static void sweep(vm_t* vm) {
             } else {
                 vm->objects = obj;
             }
-
-            free_object(obj);
+            #ifdef __GC_DEBUG__
+                fprintf(stderr, "Sweeping object ");
+                dissasemble_object(stderr, unreached);
+                fprintf(stderr, "\n");
+            #endif
+            free_object(unreached);
         }
     }
 
@@ -136,8 +140,8 @@ void gc_collect(vm_t* vm) {
     GC_LOG("Taken memory: %lu/%luB\n", before, mem_total());
 
     mark_roots(vm);
-    trace_references(&vm->gc);
-    GC_LOG("Sweeping...\n");
+    trace_references(vm);
+    GC_LOG("Begin sweeping\n");
     sweep(vm);
 
     size_t after = mem_taken();

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -1,15 +1,33 @@
 #include "gc.h"
+#include "common.h"
 #include "vm.h"
 #include "object.h"
 #include "hashtable.h"
+#include "memory.h"
 
 #define IS_MARKED(val) (val & 1)
 
-static void mark_object(struct object* obj) {
+void init_gc(struct gc_state* gc) {
+    memset(gc, 0, sizeof(*gc));
+}
+
+void free_gc(struct gc_state* gc) {
+    free(gc->worklist);
+    init_gc(gc);
+}
+
+static void mark_object(struct gc_state* gc, struct object* obj) {
     if (obj == NULL) {
         return;
     }
     obj->gc_data = 1;
+    gc->worklist = handle_capacity(gc->worklist, gc->wl_count,
+                                   &gc->wl_capacity, sizeof(*gc->worklist));
+    if (gc->worklist == NULL) {
+        fprintf(stderr, "Allocation failed for internal GC data, aborting\n");
+        exit(-11);
+    }
+    gc->worklist[gc->wl_count++] = obj;
 #ifdef __GC_DEBUG__
     GC_LOG("Marking object %p: ", obj);
     dissasemble_object(obj);
@@ -17,19 +35,19 @@ static void mark_object(struct object* obj) {
 #endif
 }
 
-static void mark_val(struct value* v) {
+static void mark_val(struct gc_state* gc, struct value* v) {
     if (v->type == VAL_OBJECT) {
-        mark_object(v->object);
+        mark_object(gc, v->object);
     }
 }
 
-static void mark_table(struct table* table) {
+static void mark_table(struct gc_state* gc, struct table* table) {
     for (size_t i = 0; i < table->capacity; ++i) {
         struct entry* e = &table->entries[i];
-        mark_val(&e->key);
+        mark_val(gc, &e->key);
         // TODO
         // if (e->key.type != VAL_NONE) {
-            mark_val(&e->val);
+            mark_val(gc, &e->val);
         // }
     }
 }
@@ -37,14 +55,14 @@ static void mark_table(struct table* table) {
 static void mark_roots(vm_t* vm) {
     // stack
     for (size_t i = 0; i < vm->stack_len; ++i) {
-        mark_val(&vm->op_stack[i]);
+        mark_val(&vm->gc, &vm->op_stack[i]);
     }
     // globals
-    mark_table(&vm->globals);
+    mark_table(&vm->gc, &vm->globals);
     // locals in frames
     for (size_t i = 0; i < vm->frame_len; ++i) {
         for (size_t j = 0; j < vm->frames->function->locals; ++j) {
-            mark_val(&vm->frames[i].slots[j]);
+            mark_val(&vm->gc, &vm->frames[i].slots[j]);
         }
     }
 }

--- a/Caby/src/gc.c
+++ b/Caby/src/gc.c
@@ -97,41 +97,17 @@ static void trace_references(vm_t* vm) {
 }
 
 static void sweep(vm_t* vm) {
-    struct object* prev = NULL;
-    struct object* obj  = vm->objects;
-    while (obj != NULL) {
-        if (IS_MARKED(obj->gc_data)) {
-            obj->gc_data = 0;
-            prev = obj;
-            obj = obj->next;
+    struct object** obj = &vm->objects;
+    while (*obj) {
+        if (IS_MARKED((*obj)->gc_data)) {
+            (*obj)->gc_data = 0;
+            obj = &(*obj)->next;
         } else {
-            struct object* unreached = obj;
-            obj = obj->next;
-            if (prev != NULL) {
-                prev->next = obj;
-            } else {
-                vm->objects = obj;
-            }
-            #ifdef __GC_DEBUG__
-                fprintf(stderr, "Sweeping object ");
-                dissasemble_object(stderr, unreached);
-                fprintf(stderr, "\n");
-            #endif
+            struct object* unreached = *obj;
+            *obj = (*obj)->next;
             free_object(unreached);
         }
     }
-
-    // struct object** obj = &vm->objects;
-    // while (*obj) {
-    //     if (IS_MARKED((*obj)->gc_data)) {
-    //         (*obj)->gc_data = 0;
-    //         obj = &(*obj)->next;
-    //     } else {
-    //         struct object* unreached = *obj;
-    //         *obj = (*obj)->next;
-    //         free_object(unreached);
-    //     }
-    // }
 }
 
 void gc_collect(vm_t* vm) {

--- a/Caby/src/gc.h
+++ b/Caby/src/gc.h
@@ -7,12 +7,16 @@
 #define GC_LOG(format, ...)
 #endif
 
+#define GC_THRESHOLD_START 1024 * 1024 // 1kb
+
 typedef struct vm_state vm_t;
 
 struct gc_state {
     size_t wl_count;
     size_t wl_capacity;
     struct object** worklist;
+
+    size_t next_gc;
 };
 
 void init_gc(struct gc_state* gc);

--- a/Caby/src/gc.h
+++ b/Caby/src/gc.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdlib.h>
+#include <stdbool.h>
 
 #ifdef __GC_DEBUG__
 #define GC_LOG(format, ...) do { fprintf(stderr, format, ##__VA_ARGS__); } while (false)
@@ -17,6 +18,8 @@ struct gc_state {
     struct object** worklist;
 
     size_t next_gc;
+
+    bool gc_off;
 };
 
 void init_gc(struct gc_state* gc);

--- a/Caby/src/gc.h
+++ b/Caby/src/gc.h
@@ -1,4 +1,10 @@
 #pragma once
 #include "vm.h"
 
+#ifdef __GC_DEBUG__
+#define GC_LOG(format, ...) do { fprintf(stderr, format, ##__VA_ARGS__); } while (false)
+#else
+#define GC_LOG(format, ...)
+#endif
+
 void gc_collect(vm_t* vm);

--- a/Caby/src/gc.h
+++ b/Caby/src/gc.h
@@ -1,10 +1,22 @@
 #pragma once
-#include "vm.h"
+#include <stdlib.h>
 
 #ifdef __GC_DEBUG__
 #define GC_LOG(format, ...) do { fprintf(stderr, format, ##__VA_ARGS__); } while (false)
 #else
 #define GC_LOG(format, ...)
 #endif
+
+typedef struct vm_state vm_t;
+
+struct gc_state {
+    size_t wl_count;
+    size_t wl_capacity;
+    struct object** worklist;
+};
+
+void init_gc(struct gc_state* gc);
+
+void free_gc(struct gc_state* gc);
 
 void gc_collect(vm_t* vm);

--- a/Caby/src/gc.h
+++ b/Caby/src/gc.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "vm.h"
+
+void gc_collect(vm_t* vm);

--- a/Caby/src/memory.c
+++ b/Caby/src/memory.c
@@ -1,11 +1,15 @@
 #include "memory.h"
 #include "memory/block_alloc.h"
+#include "vm.h"
 
 #include <stdlib.h>
 #include <string.h>
 
 
-void* vmalloc(size_t size) {
+void* vmalloc(vm_t* vm, size_t size) {
+    if (vm != NULL && mem_taken() > vm->gc.next_gc) {
+       vm->gc.next_gc *= GC_HEAP_GROW_FACTOR;
+    }
     return heap_alloc(size);
 }
 
@@ -13,8 +17,8 @@ void* vmalloc(size_t size) {
  * @param num Number of objects
  * @param size Size of each object
  */
-void* vcalloc(size_t num, size_t size) {
-    void* mem = vmalloc(num * size);
+void* vcalloc(vm_t* vm, size_t num, size_t size) {
+    void* mem = vmalloc(vm, num * size);
     memset(mem, 0, num * size);
     return mem;
 }

--- a/Caby/src/memory.c
+++ b/Caby/src/memory.c
@@ -22,3 +22,11 @@ void* vcalloc(size_t num, size_t size) {
 void vfree(void* ptr) {
     heap_free(ptr);
 }
+
+size_t mem_taken() {
+    return heap_taken();
+}
+
+size_t mem_total() {
+    return heap_total();
+}

--- a/Caby/src/memory.c
+++ b/Caby/src/memory.c
@@ -1,4 +1,5 @@
 #include "memory.h"
+#include "gc.h"
 #include "memory/block_alloc.h"
 #include "vm.h"
 
@@ -7,9 +8,16 @@
 
 
 void* vmalloc(vm_t* vm, size_t size) {
-    if (vm != NULL && mem_taken() > vm->gc.next_gc) {
-       vm->gc.next_gc *= GC_HEAP_GROW_FACTOR;
+    #ifdef __GC_STRESS__
+    if (vm != NULL) {
+        gc_collect(vm);
     }
+    #else
+    if (vm != NULL && mem_taken() > vm->gc.next_gc) {
+        gc_collect(vm);
+        vm->gc.next_gc *= GC_HEAP_GROW_FACTOR;
+    }
+    #endif
     return heap_alloc(size);
 }
 

--- a/Caby/src/memory.c
+++ b/Caby/src/memory.c
@@ -9,11 +9,6 @@ void* vmalloc(size_t size) {
     return heap_alloc(size);
 }
 
-void* vrealloc(void* ptr, size_t new_size) {
-    heap_free(ptr);
-    return heap_alloc(new_size);
-}
-
 /**
  * @param num Number of objects
  * @param size Size of each object

--- a/Caby/src/memory.c
+++ b/Caby/src/memory.c
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 
 void* vmalloc(vm_t* vm, size_t size) {

--- a/Caby/src/memory.c
+++ b/Caby/src/memory.c
@@ -9,11 +9,14 @@
 
 void* vmalloc(vm_t* vm, size_t size) {
     #ifdef __GC_STRESS__
-    if (vm != NULL) {
-        gc_collect(vm);
-    }
+    assert(vm != NULL);
+    gc_collect(vm);
     #else
-    if (vm != NULL && mem_taken() > vm->gc.next_gc) {
+    if (mem_taken() > vm->gc.next_gc || mem_taken() > mem_total()) {
+        if (mem_taken() > mem_total()) {
+            fprintf(stderr, "Out of memory, aborting...\n");
+            exit(-5);
+        }
         gc_collect(vm);
         vm->gc.next_gc *= GC_HEAP_GROW_FACTOR;
     }

--- a/Caby/src/memory.h
+++ b/Caby/src/memory.h
@@ -3,13 +3,15 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-void* vmalloc(size_t size);
+typedef struct vm_state vm_t;
+
+void* vmalloc(vm_t* vm, size_t size);
 
 /**
  * @param num Number of objects
  * @param size Size of each object
  */
-void* vcalloc(size_t num, size_t size);
+void* vcalloc(vm_t* vm, size_t num, size_t size);
 
 void vfree(void* ptr);
 

--- a/Caby/src/memory.h
+++ b/Caby/src/memory.h
@@ -13,3 +13,6 @@ void* vcalloc(size_t num, size_t size);
 
 void vfree(void* ptr);
 
+size_t mem_taken();
+
+size_t mem_total();

--- a/Caby/src/memory.h
+++ b/Caby/src/memory.h
@@ -5,8 +5,6 @@
 
 void* vmalloc(size_t size);
 
-void* vrealloc(void* ptr, size_t new_size);
-
 /**
  * @param num Number of objects
  * @param size Size of each object

--- a/Caby/src/memory/block_alloc.c
+++ b/Caby/src/memory/block_alloc.c
@@ -93,3 +93,11 @@ void heap_free(void* ptr) {
         next = next->next;
     }
 }
+
+size_t heap_total() {
+    return mempool_total;
+}
+
+size_t heap_taken() {
+    return mempool_taken;
+}

--- a/Caby/src/memory/block_alloc.c
+++ b/Caby/src/memory/block_alloc.c
@@ -35,7 +35,7 @@ void init_heap(size_t size) {
     }
 
     struct heap_header* header = init_header(mempool);
-    mempool_taken = sizeof(*header);
+    mempool_taken = 0;
     header->len = size - sizeof(*header);
 }
 
@@ -76,14 +76,14 @@ void* heap_alloc(size_t size) {
         MEM_LOG("Splitting block %lu / %lu\n", it->len, h->len);
     }
 
-    mempool_taken += it->len + sizeof(*it);
+    mempool_taken += it->len;
     MEM_LOG("Allocating %lu memory (%lu/%lu)\n", it->len + sizeof(*it), mempool_taken, mempool_total);
     return (uint8_t*)it + sizeof(*it);
 }
 
 void heap_free(void* ptr) {
     struct heap_header* it = (struct heap_header*)((uint8_t*)ptr - sizeof(*it));
-    mempool_taken -= it->len - sizeof(*it);
+    mempool_taken -= it->len;
     MEM_LOG("Freeing block, size: %lu (%lu/%lu)\n", it->len, mempool_taken, mempool_total);
     it->taken = false;
     struct heap_header* next = it->next;
@@ -92,7 +92,6 @@ void heap_free(void* ptr) {
         it->len += sizeof(*next) + next->len;
         it->next = next->next;
         next = next->next;
-        mempool_taken -= sizeof(*next);
     }
 }
 

--- a/Caby/src/memory/block_alloc.c
+++ b/Caby/src/memory/block_alloc.c
@@ -35,6 +35,7 @@ void init_heap(size_t size) {
     }
 
     struct heap_header* header = init_header(mempool);
+    mempool_taken = sizeof(*header);
     header->len = size - sizeof(*header);
 }
 
@@ -91,6 +92,7 @@ void heap_free(void* ptr) {
         it->len += sizeof(*next) + next->len;
         it->next = next->next;
         next = next->next;
+        mempool_taken -= sizeof(*next);
     }
 }
 

--- a/Caby/src/memory/block_alloc.h
+++ b/Caby/src/memory/block_alloc.h
@@ -26,3 +26,7 @@ void done_heap();
 void* heap_alloc(size_t size);
 
 void heap_free(void* ptr);
+
+size_t heap_total();
+
+size_t heap_taken();

--- a/Caby/src/object.c
+++ b/Caby/src/object.c
@@ -19,14 +19,6 @@ struct object* to_object_s(struct value val) {
     return NULL;
 }
 
-static void* allocate_object(vm_t* vm, size_t size) {
-    if (vm != NULL) {
-        return vmalloc(vm, size);
-    } else {
-        return malloc(size);
-    }
-}
-
 /// FNV-1a
 static u32 hashString(const char* key, int length) {
   u32 hash = 2166136261u;
@@ -51,7 +43,7 @@ static void init_object(vm_t* vm, struct object* obj, enum object_type type) {
 /// 'vm' can be NULL, then the string won't be added to the list of all objects
 /// and it won't be touched by GC.
 struct object_string* new_string(vm_t* vm, const char* str) {
-    struct object_string* n = allocate_object(vm, sizeof(*n));
+    struct object_string* n = vmalloc(vm, sizeof(*n));
     init_object(vm, &n->object, OBJECT_STRING);
     size_t len = strlen(str);
     n->size = len;
@@ -65,7 +57,7 @@ struct object_string* new_string(vm_t* vm, const char* str) {
 /// 'vm' can be NULL, then the string won't be added to the list of all objects
 /// and it won't be touched by GC.
 struct object_string* new_string_move(vm_t* vm, char* str, u32 len) {
-    struct object_string* n = allocate_object(vm, sizeof(*n));
+    struct object_string* n = vmalloc(vm, sizeof(*n));
     init_object(vm, &n->object, OBJECT_STRING);
     n->size = len;
     n->data = str;
@@ -84,8 +76,8 @@ struct object_string* as_string_s(struct object* object) {
     return NULL;
 }
 
-struct object_function* new_function(u8 arity, u16 locals, struct bc_chunk c, u32 name) {
-    struct object_function* f = malloc(sizeof(*f));
+struct object_function* new_function(vm_t* vm, u8 arity, u16 locals, struct bc_chunk c, u32 name) {
+    struct object_function* f = vmalloc(vm, sizeof(*f));
     f->object.type = OBJECT_FUNCTION;
     f->arity = arity;
     f->locals = locals;
@@ -105,8 +97,8 @@ struct object_function* as_function_s(struct object* object) {
     return NULL;
 }
 
-struct object_native* new_native(native_fn_t fun) {
-    struct object_native* native = malloc(sizeof(*native));
+struct object_native* new_native(vm_t* vm, native_fn_t fun) {
+    struct object_native* native = vmalloc(vm, sizeof(*native));
     native->object.type = OBJECT_NATIVE;
     native->function = fun;
     return native;

--- a/Caby/src/object.c
+++ b/Caby/src/object.c
@@ -19,6 +19,14 @@ struct object* to_object_s(struct value val) {
     return NULL;
 }
 
+static void* allocate_object(vm_t* vm, size_t size) {
+    if (vm != NULL) {
+        return vmalloc(vm, size);
+    } else {
+        return malloc(size);
+    }
+}
+
 /// FNV-1a
 static u32 hashString(const char* key, int length) {
   u32 hash = 2166136261u;
@@ -43,12 +51,12 @@ static void init_object(vm_t* vm, struct object* obj, enum object_type type) {
 /// 'vm' can be NULL, then the string won't be added to the list of all objects
 /// and it won't be touched by GC.
 struct object_string* new_string(vm_t* vm, const char* str) {
-    struct object_string* n = vmalloc(sizeof(*n));
+    struct object_string* n = allocate_object(vm, sizeof(*n));
     init_object(vm, &n->object, OBJECT_STRING);
     size_t len = strlen(str);
     n->size = len;
     n->hash = hashString(str, n->size);
-    n->data = vmalloc(len + 1);
+    n->data = vmalloc(vm, len + 1);
     memcpy(n->data, str, n->size);
     n->data[n->size] = '\0';
     return n;
@@ -57,7 +65,7 @@ struct object_string* new_string(vm_t* vm, const char* str) {
 /// 'vm' can be NULL, then the string won't be added to the list of all objects
 /// and it won't be touched by GC.
 struct object_string* new_string_move(vm_t* vm, char* str, u32 len) {
-    struct object_string* n = vmalloc(sizeof(*n));
+    struct object_string* n = allocate_object(vm, sizeof(*n));
     init_object(vm, &n->object, OBJECT_STRING);
     n->size = len;
     n->data = str;
@@ -77,7 +85,7 @@ struct object_string* as_string_s(struct object* object) {
 }
 
 struct object_function* new_function(u8 arity, u16 locals, struct bc_chunk c, u32 name) {
-    struct object_function* f = vmalloc(sizeof(*f));
+    struct object_function* f = malloc(sizeof(*f));
     f->object.type = OBJECT_FUNCTION;
     f->arity = arity;
     f->locals = locals;
@@ -98,7 +106,7 @@ struct object_function* as_function_s(struct object* object) {
 }
 
 struct object_native* new_native(native_fn_t fun) {
-    struct object_native* native = vmalloc(sizeof(*native));
+    struct object_native* native = malloc(sizeof(*native));
     native->object.type = OBJECT_NATIVE;
     native->function = fun;
     return native;

--- a/Caby/src/object.c
+++ b/Caby/src/object.c
@@ -29,39 +29,31 @@ static u32 hashString(const char* key, int length) {
   return hash;
 }
 
-/// If 'vm' is NULL then the object won't be included in VM linked list
-/// (won't be touched by GC).
 static void init_object(vm_t* vm, struct object* obj, enum object_type type) {
     obj->type = type;
-    if (vm != NULL) {
-        obj->next = vm->objects;
-        vm->objects = obj;
-        obj->gc_data = 0;
-    }
+    obj->next = vm->objects;
+    vm->objects = obj;
+    obj->gc_data = 0;
 }
 
-/// 'vm' can be NULL, then the string won't be added to the list of all objects
-/// and it won't be touched by GC.
 struct object_string* new_string(vm_t* vm, const char* str) {
     struct object_string* n = vmalloc(vm, sizeof(*n));
-    init_object(vm, &n->object, OBJECT_STRING);
     size_t len = strlen(str);
     n->size = len;
     n->hash = hashString(str, n->size);
     n->data = vmalloc(vm, len + 1);
     memcpy(n->data, str, n->size);
     n->data[n->size] = '\0';
+    init_object(vm, &n->object, OBJECT_STRING);
     return n;
 }
 
-/// 'vm' can be NULL, then the string won't be added to the list of all objects
-/// and it won't be touched by GC.
 struct object_string* new_string_move(vm_t* vm, char* str, u32 len) {
     struct object_string* n = vmalloc(vm, sizeof(*n));
-    init_object(vm, &n->object, OBJECT_STRING);
     n->size = len;
     n->data = str;
     n->hash = hashString(str, len);
+    init_object(vm, &n->object, OBJECT_STRING);
     return n;
 }
 
@@ -78,7 +70,7 @@ struct object_string* as_string_s(struct object* object) {
 
 struct object_function* new_function(vm_t* vm, u8 arity, u16 locals, struct bc_chunk c, u32 name) {
     struct object_function* f = vmalloc(vm, sizeof(*f));
-    f->object.type = OBJECT_FUNCTION;
+    init_object(vm, &f->object, OBJECT_FUNCTION);
     f->arity = arity;
     f->locals = locals;
     f->bc = c;
@@ -99,7 +91,7 @@ struct object_function* as_function_s(struct object* object) {
 
 struct object_native* new_native(vm_t* vm, native_fn_t fun) {
     struct object_native* native = vmalloc(vm, sizeof(*native));
-    native->object.type = OBJECT_NATIVE;
+    init_object(vm, &native->object, OBJECT_NATIVE);
     native->function = fun;
     return native;
 }

--- a/Caby/src/object.h
+++ b/Caby/src/object.h
@@ -116,13 +116,13 @@ struct object_string* as_string(struct object* object);
 struct object_string* as_string_s(struct object* object);
 
 /// Returns new function object, takes ownership of 'name'.
-struct object_function* new_function(u8 arity, u16 locals, struct bc_chunk c, u32 name);
+struct object_function* new_function(vm_t* vm, u8 arity, u16 locals, struct bc_chunk c, u32 name);
 
 struct object_function* as_function(struct object* object);
 
 struct object_function* as_function_s(struct object* object);
 
-struct object_native* new_native(native_fn_t fun);
+struct object_native* new_native(vm_t* vm, native_fn_t fun);
 
 struct object_native* as_native(struct object* object);
 

--- a/Caby/src/object.h
+++ b/Caby/src/object.h
@@ -97,7 +97,7 @@ bool is_object_type(struct value* val, enum object_type type);
 void free_object(struct object* obj);
 
 /// If the value is object then frees all dynamically allocated memory by it,
-/// otherwise it does nothing.
+/// otherwise it does nothing. It uses the VM internal free.
 void free_value(struct value* val);
 
 struct object* to_object(struct value val);

--- a/Caby/src/object.h
+++ b/Caby/src/object.h
@@ -9,6 +9,9 @@
 #include "common.h"
 #include "bytecode.h"
 
+/// Forward decl
+typedef struct vm_state vm_t;
+
 enum object_type {
     OBJECT_STRING,
     OBJECT_FUNCTION,
@@ -20,7 +23,10 @@ enum object_type {
  * functions and so on.
  */
 struct object {
+    struct object* next;
     enum object_type type;
+    /// Internal data used for GC (ie. marked, generation and so on...)
+    u8 gc_data;
 };
 
 struct object_string {
@@ -99,11 +105,11 @@ struct object* to_object(struct value val);
 struct object* to_object_s(struct value val);
 
 /// Returns new object string with contents of 'str', the string is copied.
-struct object_string* new_string(const char* str);
+struct object_string* new_string(vm_t* vm, const char* str);
 
 /// Takes ownership of str, which is zero terminated string.
 /// len is the length of the string without zero terminator.
-struct object_string* new_string_move(char* str, u32 len);
+struct object_string* new_string_move(vm_t* vm, char* str, u32 len);
 
 struct object_string* as_string(struct object* object);
 

--- a/Caby/src/serializer.c
+++ b/Caby/src/serializer.c
@@ -135,7 +135,9 @@ void serialize_constant_pool(FILE* f, vm_t* vm) {
 vm_t serialize(FILE* f, u32* ep) {
     vm_t vm;
     init_vm_state(&vm);
+    vm.gc.gc_off = true;
     serialize_constant_pool(f, &vm);
     *ep = read_4bytes_be(f);
+    vm.gc.gc_off = false;
     return vm;
 }

--- a/Caby/src/serializer.c
+++ b/Caby/src/serializer.c
@@ -86,7 +86,7 @@ void serialize_instruction(FILE* f, struct bc_chunk* c) {
     }
 }
 
-struct object* serialize_object(FILE* f) {
+struct object* serialize_object(FILE* f, vm_t* vm) {
     u8 tag;
     fread(&tag, 1, 1, f);
 
@@ -101,16 +101,16 @@ struct object* serialize_object(FILE* f) {
             for (u32 i = 0; i < body_len; ++i) {
                 serialize_instruction(f, &bc);
             }
-            return (struct object*)new_function(parameters, locals_cnt, bc, name);
+            return (struct object*)new_function(vm, parameters, locals_cnt, bc, name);
         }
         case TAG_STRING: {
             u32 len = read_4bytes_be(f);
-            char *str = vmalloc(NULL, len + 1);
+            char *str = vmalloc(vm, len + 1);
             fread(str, 1, len, f);
             str[len] = '\0';
             // These guys don't have to be in object linked list, since they
             // will exist for the whole duration of the program.
-            struct object_string* obj_str = new_string_move(NULL, str, len);
+            struct object_string* obj_str = new_string_move(vm, str, len);
             return (struct object*)obj_str;
         }
         default:
@@ -119,24 +119,23 @@ struct object* serialize_object(FILE* f) {
     }
 }
 
-struct constant_pool serialize_constant_pool(FILE* f) {
-    struct constant_pool cp;
-    init_constant_pool(&cp);
-
+void serialize_constant_pool(FILE* f, vm_t* vm) {
     u32 len = read_4bytes_be(f);
     for (u32 i = 0; i < len; ++i) {
-        struct object* obj = serialize_object(f);
+        struct object* obj = serialize_object(f, vm);
         if (obj == NULL) {
+            fprintf(stderr, "Unable to serialize object at %u.\n", i);
             exit(-3);
         }
 
-        write_constant_pool(&cp, obj);
+        write_constant_pool(&vm->const_pool, obj);
     }
-
-    return cp;
 }
 
-void serialize(FILE* f, struct constant_pool* cp, u32* ep) {
-    *cp = serialize_constant_pool(f);
+vm_t serialize(FILE* f, u32* ep) {
+    vm_t vm;
+    init_vm_state(&vm);
+    serialize_constant_pool(f, &vm);
     *ep = read_4bytes_be(f);
+    return vm;
 }

--- a/Caby/src/serializer.c
+++ b/Caby/src/serializer.c
@@ -108,7 +108,9 @@ struct object* serialize_object(FILE* f) {
             char *str = vmalloc(len + 1);
             fread(str, 1, len, f);
             str[len] = '\0';
-            struct object_string* obj_str = new_string_move(str, len);
+            // These guys don't have to be in object linked list, since they
+            // will exist for the whole duration of the program.
+            struct object_string* obj_str = new_string_move(NULL, str, len);
             return (struct object*)obj_str;
         }
         default:

--- a/Caby/src/serializer.c
+++ b/Caby/src/serializer.c
@@ -105,7 +105,7 @@ struct object* serialize_object(FILE* f) {
         }
         case TAG_STRING: {
             u32 len = read_4bytes_be(f);
-            char *str = vmalloc(len + 1);
+            char *str = vmalloc(NULL, len + 1);
             fread(str, 1, len, f);
             str[len] = '\0';
             // These guys don't have to be in object linked list, since they

--- a/Caby/src/serializer.h
+++ b/Caby/src/serializer.h
@@ -18,8 +18,8 @@ u16 read_2bytes_be(FILE* f);
 
 void serialize_instruction(FILE* f, struct bc_chunk* c);
 
-struct object* serialize_object(FILE* f);
+struct object* serialize_object(FILE* f, vm_t* vm);
 
-struct constant_pool serialize_constant_pool(FILE* f);
+void serialize_constant_pool(FILE* f, vm_t* vm);
 
-void serialize(FILE* f, struct constant_pool* cp, u32* ep);
+vm_t serialize(FILE* f, u32* ep);

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -89,6 +89,11 @@ static void pop_frame(vm_t* vm) {
 /// Does not free constant pool, since that
 /// is not owned.
 void free_vm_state(vm_t* vm) {
+    while (vm->objects) {
+        struct object* to_free = vm->objects;
+        vm->objects = vm->objects->next;
+        free_object(to_free);
+    }
     free_constant_pool(&vm->const_pool);
     free_table(&vm->globals);
     free(vm->locals);

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -43,7 +43,6 @@ static void runtime_error(const char* str, ...) {
 }
 
 static void def_native(vm_t* vm, const char* name, native_fn_t fun) {
-    // We have vm but pass null to not allocate the object on the GC territory
     push(vm, NEW_OBJECT(new_string(vm, name)));
     push(vm, NEW_OBJECT(new_native(vm, fun)));
     table_set(&vm->globals, vm->op_stack[0], vm->op_stack[1]);

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -89,6 +89,7 @@ static void pop_frame(vm_t* vm) {
 /// Does not free constant pool, since that
 /// is not owned.
 void free_vm_state(vm_t* vm) {
+    // Free all objects in VM heap
     while (vm->objects) {
         struct object* to_free = vm->objects;
         vm->objects = vm->objects->next;

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -42,7 +42,7 @@ static void runtime_error(const char* str, ...) {
 }
 
 static void def_native(vm_t* vm, const char* name, native_fn_t fun) {
-    push(vm, NEW_OBJECT(new_string(name)));
+    push(vm, NEW_OBJECT(new_string(vm, name)));
     push(vm, NEW_OBJECT(new_native(fun)));
     table_set(&vm->globals, vm->op_stack[0], vm->op_stack[1]);
     pop(vm);
@@ -124,7 +124,7 @@ static struct object_string* pop_string(vm_t* vm) {
 #define CURRENT_FUNCTION() (TOP_FRAME().function)
 
 /// Returns new 'struct value' containing string object which is contatenation of o1 and o2
-struct value interpret_string_concat(struct object* o1, struct object* o2) {
+struct value interpret_string_concat(vm_t* vm, struct object* o1, struct object* o2) {
     struct object_string* str1 = as_string(o1);
     struct object_string* str2 = as_string(o2);
 
@@ -134,7 +134,7 @@ struct value interpret_string_concat(struct object* o1, struct object* o2) {
     memcpy(new_char + str1->size, str2->data, str2->size);
     new_char[size] = '\0';
 
-    return NEW_OBJECT(new_string_move(new_char, size));
+    return NEW_OBJECT(new_string_move(vm, new_char, size));
 }
 
 enum interpret_result interpret_print(vm_t* vm) {
@@ -254,7 +254,7 @@ static enum interpret_result interpret_ins(vm_t* vm, u8 ins) {
             } else if (v1.type == VAL_OBJECT && v2.type == VAL_OBJECT
                     && v1.object->type == OBJECT_STRING
                     && v2.object->type == OBJECT_STRING) {
-                push(vm, interpret_string_concat(v1.object, v2.object));
+                push(vm, interpret_string_concat(vm, v1.object, v2.object));
             } else {
                 runtime_error("Incopatible types for operator '+'\n");
                 return INTERPRET_ERROR;

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -1,4 +1,5 @@
 #include "vm.h"
+#include "gc.h"
 #include "bytecode.h"
 #include "common.h"
 #include "hashtable.h"
@@ -58,6 +59,7 @@ void init_vm_state(vm_t* vm) {
     vm->frame_len = 0;
     vm->stack_cap = 0;
     vm->stack_len = 0;
+    init_gc(&vm->gc);
 }
 
 void alloc_frames(vm_t* vm) {
@@ -89,6 +91,7 @@ void free_vm_state(vm_t* vm) {
     free_table(&vm->globals);
     free(vm->locals);
     free(vm->op_stack);
+    free_gc(&vm->gc);
     init_vm_state(vm);
 }
 

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -43,7 +43,8 @@ static void runtime_error(const char* str, ...) {
 }
 
 static void def_native(vm_t* vm, const char* name, native_fn_t fun) {
-    push(vm, NEW_OBJECT(new_string(vm, name)));
+    // We have vm but pass null to not allocate the object on the GC territory
+    push(vm, NEW_OBJECT(new_string(NULL, name)));
     push(vm, NEW_OBJECT(new_native(fun)));
     table_set(&vm->globals, vm->op_stack[0], vm->op_stack[1]);
     pop(vm);

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -132,7 +132,7 @@ struct value interpret_string_concat(vm_t* vm, struct object* o1, struct object*
     struct object_string* str2 = as_string(o2);
 
     u32 size = str1->size + str2->size;
-    char* new_char = vmalloc(size + 1);
+    char* new_char = vmalloc(vm, size + 1);
     memcpy(new_char, str1->data, str1->size);
     memcpy(new_char + str1->size, str2->data, str2->size);
     new_char[size] = '\0';

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -60,6 +60,7 @@ void init_vm_state(vm_t* vm) {
     vm->frame_len = 0;
     vm->stack_cap = 0;
     vm->stack_len = 0;
+    vm->objects = NULL;
     init_gc(&vm->gc);
 }
 

--- a/Caby/src/vm.h
+++ b/Caby/src/vm.h
@@ -49,7 +49,7 @@ void init_vm_state(vm_t* vm);
 
 void free_vm_state(vm_t* vm);
 
-int interpret(struct constant_pool* cp, u32 ep);
+int interpret(vm_t* vm, u32 ep);
 
 void push(vm_t* vm, struct value val);
 

--- a/Caby/src/vm.h
+++ b/Caby/src/vm.h
@@ -36,6 +36,9 @@ typedef struct vm_state {
     struct table globals;
 
     struct value* locals;
+
+    /// Linked list of all objects in a program
+    struct object* objects;
 } vm_t;
 
 void init_vm_state(vm_t* vm);

--- a/Caby/src/vm.h
+++ b/Caby/src/vm.h
@@ -7,6 +7,7 @@
 #include "gc.h"
 
 #define FRAME_DEPTH 128
+#define GC_HEAP_GROW_FACTOR 2
 
 enum interpret_result {
     INTERPRET_CONTINUE,

--- a/Caby/src/vm.h
+++ b/Caby/src/vm.h
@@ -4,6 +4,7 @@
 #include "object.h"
 #include "hashtable.h"
 #include "native.h"
+#include "gc.h"
 
 #define FRAME_DEPTH 128
 
@@ -39,6 +40,8 @@ typedef struct vm_state {
 
     /// Linked list of all objects in a program
     struct object* objects;
+
+    struct gc_state gc;
 } vm_t;
 
 void init_vm_state(vm_t* vm);

--- a/Caby/tests/hashmap_test.c
+++ b/Caby/tests/hashmap_test.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 
 #include "test.h"
+#include "../src/vm.h"
 #include "../src/hashtable.h"
 #include "../src/memory/block_alloc.h"
 
@@ -13,9 +14,11 @@ TEST(HashMapBasic) {
     ASSERT_W(t.capacity == 0);
     ASSERT_W(t.count == 0);
 
+    vm_t vm;
+    init_vm_state(&vm);
     struct value val_out;
 
-    struct value key1 = NEW_OBJECT(new_string(NULL, "Hello, World!"));
+    struct value key1 = NEW_OBJECT(new_string(&vm, "Hello, World!"));
     table_set(&t, key1, NEW_INT(3));
     ASSERT_W(t.count == 1);
     ASSERT_W(table_get(&t, key1, &val_out));
@@ -27,9 +30,9 @@ TEST(HashMapBasic) {
     ASSERT_W(val_out.type == VAL_INT);
     ASSERT_W(val_out.integer == 5);
 
-    struct value key2 = NEW_OBJECT(new_string(NULL, "FOO"));
-    struct value key3 = NEW_OBJECT(new_string(NULL, "BAR"));
-    struct value key4 = NEW_OBJECT(new_string(NULL, "BAZ"));
+    struct value key2 = NEW_OBJECT(new_string(&vm, "FOO"));
+    struct value key3 = NEW_OBJECT(new_string(&vm, "BAR"));
+    struct value key4 = NEW_OBJECT(new_string(&vm, "BAZ"));
     struct value key5 = NEW_INT(1);
     struct value key6 = NEW_INT(2);
 
@@ -54,8 +57,8 @@ TEST(HashMapBasic) {
     ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
 
     // Check reads/writes through equal bot not same "object" keys
-    struct value key7_1 = NEW_OBJECT(new_string(NULL, "FOOBAR"));
-    struct value key7_2 = NEW_OBJECT(new_string(NULL, "FOOBAR"));
+    struct value key7_1 = NEW_OBJECT(new_string(&vm, "FOOBAR"));
+    struct value key7_2 = NEW_OBJECT(new_string(&vm, "FOOBAR"));
     ASSERT_W(table_set(&t, key7_1, NEW_INT(9)));
     ASSERT_W(table_get(&t, key7_2, &val_out));
     ASSERT_W(val_out.type == VAL_INT && val_out.integer == 9);
@@ -87,7 +90,7 @@ TEST(HashMapBasic) {
 
     // Add a couple more entries to stress reallocation
     struct value key7 = NEW_DOUBLE(1.111);
-    struct value key8 = NEW_OBJECT(new_string(NULL, "key8"));
+    struct value key8 = NEW_OBJECT(new_string(&vm, "key8"));
     struct value key9 = NEW_BOOL(true);
     struct value key10 = NEW_BOOL(false);
 
@@ -395,6 +398,8 @@ TEST(HashMapBasic) {
     ASSERT_W(!table_get(&t, key9, &val_out));
     ASSERT_W(!table_get(&t, key10, &val_out));
 
+    free_table(&t);
+    free_vm_state(&vm);
     done_heap();
     return 0;
 }

--- a/Caby/tests/hashmap_test.c
+++ b/Caby/tests/hashmap_test.c
@@ -16,6 +16,7 @@ TEST(HashMapBasic) {
 
     vm_t vm;
     init_vm_state(&vm);
+    vm.gc.gc_off = true;
     struct value val_out;
 
     struct value key1 = NEW_OBJECT(new_string(&vm, "Hello, World!"));

--- a/Caby/tests/hashmap_test.c
+++ b/Caby/tests/hashmap_test.c
@@ -15,7 +15,7 @@ TEST(HashMapBasic) {
 
     struct value val_out;
 
-    struct value key1 = NEW_OBJECT(new_string("Hello, World!"));
+    struct value key1 = NEW_OBJECT(new_string(NULL, "Hello, World!"));
     table_set(&t, key1, NEW_INT(3));
     ASSERT_W(t.count == 1);
     ASSERT_W(table_get(&t, key1, &val_out));
@@ -27,9 +27,9 @@ TEST(HashMapBasic) {
     ASSERT_W(val_out.type == VAL_INT);
     ASSERT_W(val_out.integer == 5);
 
-    struct value key2 = NEW_OBJECT(new_string("FOO"));
-    struct value key3 = NEW_OBJECT(new_string("BAR"));
-    struct value key4 = NEW_OBJECT(new_string("BAZ"));
+    struct value key2 = NEW_OBJECT(new_string(NULL, "FOO"));
+    struct value key3 = NEW_OBJECT(new_string(NULL, "BAR"));
+    struct value key4 = NEW_OBJECT(new_string(NULL, "BAZ"));
     struct value key5 = NEW_INT(1);
     struct value key6 = NEW_INT(2);
 
@@ -54,8 +54,8 @@ TEST(HashMapBasic) {
     ASSERT_W(val_out.type == VAL_OBJECT && val_out.object == key1.object);
 
     // Check reads/writes through equal bot not same "object" keys
-    struct value key7_1 = NEW_OBJECT(new_string("FOOBAR"));
-    struct value key7_2 = NEW_OBJECT(new_string("FOOBAR"));
+    struct value key7_1 = NEW_OBJECT(new_string(NULL, "FOOBAR"));
+    struct value key7_2 = NEW_OBJECT(new_string(NULL, "FOOBAR"));
     ASSERT_W(table_set(&t, key7_1, NEW_INT(9)));
     ASSERT_W(table_get(&t, key7_2, &val_out));
     ASSERT_W(val_out.type == VAL_INT && val_out.integer == 9);
@@ -87,7 +87,7 @@ TEST(HashMapBasic) {
 
     // Add a couple more entries to stress reallocation
     struct value key7 = NEW_DOUBLE(1.111);
-    struct value key8 = NEW_OBJECT(new_string("key8"));
+    struct value key8 = NEW_OBJECT(new_string(NULL, "key8"));
     struct value key9 = NEW_BOOL(true);
     struct value key10 = NEW_BOOL(false);
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -32,10 +32,10 @@ for file in expected/*.exp; do
 
     # Run VM
     ${VM} execute a.out > out/${file}.out;
-    if [[ $? -ne 0 ]]; then
-        printf "${RED}Test ${file} failed - Interpreting failed${NC}\n";
+    EXIT_CODE=$?
+    if [[ ${EXIT_CODE} -ne 0 ]]; then
+        printf "${RED}Test ${file} failed - Interpreting failed with exit code ${EXIT_CODE}${NC}\n";
         rm a.out;
-        rm out.tmp;
         continue;
     fi;
 


### PR DESCRIPTION
PR introduces simple mark and sweep garbage collector.
The collector runs at certain thresholds or when out of memory.

The vm_state now has linked list of all allocated camel objects. This is then used when sweeping. Every camel object and it's internals are now allocated on the VM internal heap. All other structures aren't (eg. arrays, stacks, tables etc.). There are some exceptions to this, for example object string data (the C string that it points to) is allocated on the VM heap also, but the bytecode which function consist of isn't.

The serializer has been refactored, because it needs access to the VM linked list of objects when serializing. This unfortunately led to worse code quality, and VM is passed as argument which the serializator writes to.

There is also a flag in the VM to turn the GC off. This can be useful for serialization or for example hashmap test uses this. Since we don't want the GC to run there.

There were two build modes added, one is GC, which is the same as Debug but adds GC loggging and runs gc on every allocation. The second one is GC_Test, which just runs the GC on every allocation but doesn't log.

Lastly, the github pipeline testing now runs the GC at every allocation. This is probably not ideal. This however comes from the fact that the testing is lackluster, and should be looked upon and improved.

Closes #25 