### PR TITLE
Change methods to be functions with indexes stored in class

### DIFF
--- a/Caby/README.md
+++ b/Caby/README.md
@@ -26,12 +26,9 @@ The string is NOT zero terminated.
 The code is an array of instruction opcodes (one byte) and its location in the source file (4 bytes). Functions themselves are invisible to the VM even when in constant pool. To call them you need to define them in main. Push them onto stack and then use SetVal instruction.
 - Class
 ```
-0x02 | name - 4 byte index to constant pool | methods count - 2 bytes | Function* ...
+0x02 | name - 4 byte index to constant pool | methods count - 2 bytes | 4 bytes index to constant pool *
 ```
-Functions correspond to the Function object above.
-Contructor is not included in the Class object. It should
-instead be serialized as normal function with the same
-name as the class (not necessarily same index to cp).
+Methods are stored as normal functions, the class keeps only indexes to them.
 
 Size of constant pool is 2^32 (so it can be indexed by 32bit int).
 ### Entry point

--- a/Caby/src/object.h
+++ b/Caby/src/object.h
@@ -88,6 +88,7 @@ struct value {
 
 /// To improve clarity of some functions
 #define AS_OBJECT(VAL) NEW_OBJECT(VAL)
+#define AS_CINT(VAL) ((VAL).integer)
 
 /*
  * Following functions serve as constructors, converters and checkers

--- a/Caby/src/serializer.c
+++ b/Caby/src/serializer.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include "serializer.h"
 #include "bytecode.h"
 #include "common.h"
@@ -127,8 +128,12 @@ struct object* serialize_object(FILE* f, vm_t* vm) {
             struct table methods;
             init_table(&methods);
             for (size_t i = 0; i < methods_len; ++ i) {
-                struct object_function* fun = serialize_function(f, vm);
-                table_set(&methods, NEW_OBJECT(vm->const_pool.data[fun->name]), NEW_OBJECT((struct object*)fun));
+                u32 fun = read_4bytes_le(f);
+                struct object_function* method = as_function_s(vm->const_pool.data[fun]);
+                assert(method != NULL);
+                struct object_string* name = as_string_s(vm->const_pool.data[method->name]);
+                assert(name != NULL);
+                table_set(&methods, NEW_OBJECT(name), NEW_INT(fun));
             }
             return (struct object*)new_class(vm, name, methods);
         }

--- a/Caby/src/vm.c
+++ b/Caby/src/vm.c
@@ -545,11 +545,14 @@ static enum interpret_result interpret_ins(vm_t* vm, u8 ins) {
             struct object* obj = target.object;
             if (obj->type == OBJECT_INSTANCE) {
                 struct object_instance* instance = as_instance(obj);
-                struct value method;
-                table_get(&instance->klass->methods, NEW_OBJECT(vm->const_pool.data[name]), &method);
-                struct object_function* f = as_function(method.object);
+                struct value method_idx;
+                table_get(&instance->klass->methods, 
+                          NEW_OBJECT(vm->const_pool.data[name]), &method_idx);
+                u32 idx = AS_CINT(method_idx);
+                struct object_function* f = as_function(vm->const_pool.data[idx]);
                 if (arity != f->arity) {
-                    runtime_error(vm, "Got '%d' arguments, expected '%d'", arity, f->arity);
+                    runtime_error(vm, "Got '%d' arguments, expected '%d'", 
+                                  arity, f->arity);
                     return INTERPRET_ERROR;
                 }
                 push_frame(vm, f);

--- a/Cacom/src/compiler.rs
+++ b/Cacom/src/compiler.rs
@@ -422,7 +422,7 @@ impl Compiler {
             StmtType::Class { name, statements } => {
                 let name_idx = self.constant_pool.add(Object::from(name.clone()));
 
-                let mut methods: Vec<Function> = vec![];
+                let mut methods: Vec<ConstantPoolIndex> = vec![];
 
                 // TODO: This should be handled at the grammar level
                 for stmt in statements {
@@ -437,7 +437,8 @@ impl Compiler {
                         } => {
                             let name = self.constant_pool.add(Object::from(name.clone()));
                             let method = self.compile_fun(name, parameters, body)?;
-                            methods.push(method);
+                            let method_idx = self.constant_pool.add(Object::Function(method));
+                            methods.push(method_idx);
                         }
                         _ => panic!("Class can only contain method or member definitions."),
                     };
@@ -651,20 +652,6 @@ pub fn compile(ast: &Stmt) -> Result<(ConstantPool, ConstantPoolIndex), &'static
                 parameters_cnt,
                 locals_cnt,
             }),
-            Object::Class { name, methods } => Object::Class {
-                name,
-                methods: methods
-                    .into_iter()
-                    .map(|f| Function {
-                        name: f.name,
-                        parameters_cnt: f.parameters_cnt,
-                        locals_cnt: f.locals_cnt,
-                        body: Code {
-                            code: jump_pass(f.body.code),
-                        },
-                    })
-                    .collect(),
-            },
             _ => f,
         })
         .collect();

--- a/Cacom/src/objects.rs
+++ b/Cacom/src/objects.rs
@@ -22,7 +22,7 @@ pub enum Object {
     Function(Function),
     Class {
         name: ConstantPoolIndex,
-        methods: Vec<Function>,
+        methods: Vec<ConstantPoolIndex>,
     },
 }
 
@@ -157,7 +157,7 @@ impl Serializable for Object {
                 f.write_all(&name.to_le_bytes())?;
                 f.write_all(&(u16::try_from(methods.len()).unwrap()).to_le_bytes())?;
                 for method in methods {
-                    method.serialize(f)?;
+                    f.write_all(&method.to_le_bytes())?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
Change methods to not be stored inside of class object.
Methods are now on the same level as functions, with the
exception that they are not a public symbol (functions are declared as vals).
Classes contains index to the constant pool that points at the methods.
This simplified some serialization code, and it might also keep things
cleaner in the future.
Closes #49.